### PR TITLE
chore: add PR template, backup command, and prod limits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- What changed and why? -->
+
+## Related issue(s)
+<!-- Closes #XX, closes #YY -->
+
+## Changes
+<!-- Bullet list of what was done -->
+
+## How to test
+<!-- Commands or steps to verify. Remove this section if not applicable. -->

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ backups/*.sql
 # Temporary files
 *.tmp
 *.log
+
+# Claude
+CLAUDE.md
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down logs psql restart
+.PHONY: help up down logs psql restart backup
 
 help: ## Show this help
 	@echo "Shared PostgreSQL - Available Commands"
@@ -18,3 +18,9 @@ psql: ## Open PostgreSQL shell (admin)
 	docker exec -it shared-postgres psql -U $$(grep POSTGRES_USER .env | cut -d= -f2)
 
 restart: down up ## Restart shared-postgres
+
+backup: ## Dump all databases to backups/
+	@mkdir -p backups
+	docker exec shared-postgres pg_dumpall -U $$(grep POSTGRES_USER .env | cut -d= -f2) > backups/backup_$$(date +%Y%m%d_%H%M%S).sql
+	@echo "Backup saved to backups/"
+	@ls -lh backups/*.sql | tail -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - "127.0.0.1:5432:5432"  # Localhost only - accessible for DBeaver
     env_file: .env
+    mem_limit: 1g
+    shm_size: 256mb
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./init-scripts:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## Summary

Housekeeping improvements: standardize PRs, add a backup command, gitignore Claude config, and set production memory limits.

## Changes

- **`.github/pull_request_template.md`** — PR template with Summary, Related issues, Changes, and How to test sections
- **`.gitignore`** — exclude `CLAUDE.md` and `.claude/` from the repo
- **`Makefile`** — add `make backup` target (pg_dumpall to `backups/`)
- **`docker-compose.yml`** — add `mem_limit: 1g` and `shm_size: 256mb` for production safety

## How to test

- `make help` should list the new `backup` target
- `docker compose config` should show memory limits
- New PRs should use the template automatically