### PR TITLE
chore: archive repo — moved to vpatrin/infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# ⚠️ Archived
+
+This repository has been absorbed into [vpatrin/infra](https://github.com/vpatrin/infra).
+
+- **Moved to:** `infra/services/postgres/`
+- **Date:** 2026-03-16
+- **Last commit before archive:** `c973223`
+
+---
+
 # Shared PostgreSQL
 
 One PostgreSQL container, isolated databases per project. Only `.env` changes between environments.


### PR DESCRIPTION
## Summary

Add archive notice to README. This repo has been absorbed into [vpatrin/infra](https://github.com/vpatrin/infra) (`services/postgres/`).

## Changes

- Added archive banner with destination path, date, and last commit hash

## After merge

```bash
gh repo archive vpatrin/shared-postgres --yes
```